### PR TITLE
Allow bad data

### DIFF
--- a/arrow-json/src/reader/boolean_array.rs
+++ b/arrow-json/src/reader/boolean_array.rs
@@ -24,18 +24,16 @@ use crate::reader::tape::{Tape, TapeElement};
 use crate::reader::ArrayDecoder;
 
 pub struct BooleanArrayDecoder {
-    is_nullable: bool
+    is_nullable: bool,
 }
 
 impl BooleanArrayDecoder {
     pub fn new(is_nullable: bool) -> Self {
-        Self {
-            is_nullable
-        }
+        Self { is_nullable }
     }
 }
 
-impl ArrayDecoder for BooleanArrayDecoder {    
+impl ArrayDecoder for BooleanArrayDecoder {
     fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayData, ArrowError> {
         let mut builder = BooleanBuilder::with_capacity(pos.len());
         for p in pos {
@@ -55,6 +53,6 @@ impl ArrayDecoder for BooleanArrayDecoder {
             TapeElement::Null => self.is_nullable,
             TapeElement::True | TapeElement::False => true,
             _ => false,
-        }  
+        }
     }
 }

--- a/arrow-json/src/reader/decimal_array.rs
+++ b/arrow-json/src/reader/decimal_array.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 
 use arrow_array::builder::PrimitiveBuilder;
 use arrow_array::types::DecimalType;
-use arrow_array::{Array};
+use arrow_array::Array;
 use arrow_cast::parse::parse_decimal;
 use arrow_data::ArrayData;
 use arrow_schema::ArrowError;
@@ -81,8 +81,7 @@ where
             TapeElement::Null => self.is_nullable,
             TapeElement::String(idx) => {
                 let s = tape.get_string(idx);
-                parse_decimal::<D>(s, self.precision, self.scale)
-                    .is_ok()
+                parse_decimal::<D>(s, self.precision, self.scale).is_ok()
             }
             TapeElement::Number(idx) => {
                 let s = tape.get_string(idx);

--- a/arrow-json/src/reader/json_array.rs
+++ b/arrow-json/src/reader/json_array.rs
@@ -89,4 +89,11 @@ impl ArrayDecoder for JsonArrayDecoder {
 
         Ok(builder.finish().into_data())
     }
+
+    fn validate_row(&self, tape: &Tape<'_>, pos: u32) -> bool {
+        match tape.get(pos) {
+            TapeElement::Null => self.is_nullable,
+            _ => true,
+        }
+    }
 }

--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -133,7 +133,7 @@ impl<O: OffsetSizeTrait> ArrayDecoder for ListArrayDecoder<O> {
                 return false;
             }
         }
-        
+
         true
     }
 }

--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -111,4 +111,29 @@ impl<O: OffsetSizeTrait> ArrayDecoder for ListArrayDecoder<O> {
         // Validated lengths above
         Ok(unsafe { data.build_unchecked() })
     }
+
+    fn validate_row(&self, tape: &Tape<'_>, pos: u32) -> bool {
+        let end_idx = match (tape.get(pos), self.is_nullable) {
+            (TapeElement::StartList(end_idx), _) => end_idx,
+            (TapeElement::Null, true) => {
+                return true;
+            }
+            _ => return false,
+        };
+
+        let mut cur_idx = pos + 1;
+        while cur_idx < end_idx {
+            if !self.decoder.validate_row(tape, cur_idx) {
+                return false;
+            }
+            // Advance to next field
+            if let Ok(next) = tape.next(cur_idx, "list value") {
+                cur_idx = next;
+            } else {
+                return false;
+            }
+        }
+        
+        true
+    }
 }

--- a/arrow-json/src/reader/map_array.rs
+++ b/arrow-json/src/reader/map_array.rs
@@ -153,4 +153,34 @@ impl ArrayDecoder for MapArrayDecoder {
         // Valid by construction
         Ok(unsafe { builder.build_unchecked() })
     }
+
+    fn validate_row(&self, tape: &Tape<'_>, pos: u32) -> bool {
+        let end_idx = match tape.get(pos) {
+            TapeElement::StartObject(end_idx) => end_idx,
+            TapeElement::Null => {
+                return self.is_nullable;
+            }
+            _ => return false,
+        };
+
+        let mut cur_idx = pos + 1;
+        while cur_idx < end_idx {
+            let key = cur_idx;
+            let Ok(value) = tape.next(key, "map key") else {
+                return false;
+            };
+            
+            if let Ok(i) = tape.next(value, "map value") {
+                cur_idx = i;
+            } else {
+                return false;
+            } 
+
+            if !(self.keys.validate_row(tape, key) && self.values.validate_row(tape, value)) {
+                return false;
+            }
+        }
+        
+        true
+    }
 }

--- a/arrow-json/src/reader/map_array.rs
+++ b/arrow-json/src/reader/map_array.rs
@@ -169,18 +169,18 @@ impl ArrayDecoder for MapArrayDecoder {
             let Ok(value) = tape.next(key, "map key") else {
                 return false;
             };
-            
+
             if let Ok(i) = tape.next(value, "map value") {
                 cur_idx = i;
             } else {
                 return false;
-            } 
+            }
 
             if !(self.keys.validate_row(tape, key) && self.values.validate_row(tape, value)) {
                 return false;
             }
         }
-        
+
         true
     }
 }

--- a/arrow-json/src/reader/null_array.rs
+++ b/arrow-json/src/reader/null_array.rs
@@ -32,4 +32,8 @@ impl ArrayDecoder for NullArrayDecoder {
         }
         ArrayDataBuilder::new(DataType::Null).len(pos.len()).build()
     }
+
+    fn validate_row(&self, tape: &Tape<'_>, pos: u32) -> bool {
+        matches!(tape.get(pos), TapeElement::Null)
+    }
 }

--- a/arrow-json/src/reader/primitive_array.rs
+++ b/arrow-json/src/reader/primitive_array.rs
@@ -90,7 +90,6 @@ impl<P: ArrowPrimitiveType> PrimitiveArrayDecoder<P> {
     }
 }
 
-
 impl<P> ArrayDecoder for PrimitiveArrayDecoder<P>
 where
     P: ArrowPrimitiveType + Parser,
@@ -159,7 +158,7 @@ where
 
         Ok(builder.finish().into_data())
     }
-    
+
     fn validate_row(&self, tape: &Tape<'_>, pos: u32) -> bool {
         match tape.get(pos) {
             TapeElement::Null => self.is_nullable,
@@ -169,7 +168,8 @@ where
             }
             TapeElement::Number(idx) => {
                 let s = tape.get_string(idx);
-                let v: Option<<P as ArrowPrimitiveType>::Native> = ParseJsonNumber::parse(s.as_bytes());
+                let v: Option<<P as ArrowPrimitiveType>::Native> =
+                    ParseJsonNumber::parse(s.as_bytes());
                 v.is_some()
             }
             TapeElement::F32(v) => {

--- a/arrow-json/src/reader/primitive_array.rs
+++ b/arrow-json/src/reader/primitive_array.rs
@@ -75,18 +75,21 @@ impl ParseJsonNumber for f64 {
 
 pub struct PrimitiveArrayDecoder<P: ArrowPrimitiveType> {
     data_type: DataType,
+    is_nullable: bool,
     // Invariant and Send
     phantom: PhantomData<fn(P) -> P>,
 }
 
 impl<P: ArrowPrimitiveType> PrimitiveArrayDecoder<P> {
-    pub fn new(data_type: DataType) -> Self {
+    pub fn new(data_type: DataType, is_nullable: bool) -> Self {
         Self {
             data_type,
+            is_nullable,
             phantom: Default::default(),
         }
     }
 }
+
 
 impl<P> ArrayDecoder for PrimitiveArrayDecoder<P>
 where
@@ -155,5 +158,46 @@ where
         }
 
         Ok(builder.finish().into_data())
+    }
+    
+    fn validate_row(&self, tape: &Tape<'_>, pos: u32) -> bool {
+        match tape.get(pos) {
+            TapeElement::Null => self.is_nullable,
+            TapeElement::String(idx) => {
+                let s = tape.get_string(idx);
+                P::parse(s).is_some()
+            }
+            TapeElement::Number(idx) => {
+                let s = tape.get_string(idx);
+                let v: Option<<P as ArrowPrimitiveType>::Native> = ParseJsonNumber::parse(s.as_bytes());
+                v.is_some()
+            }
+            TapeElement::F32(v) => {
+                let v = f32::from_bits(v);
+                let v: Option<<P as ArrowPrimitiveType>::Native> = NumCast::from(v);
+                v.is_some()
+            }
+            TapeElement::I32(v) => {
+                let v: Option<<P as ArrowPrimitiveType>::Native> = NumCast::from(v);
+                v.is_some()
+            }
+            TapeElement::F64(high) => match tape.get(pos + 1) {
+                TapeElement::F32(low) => {
+                    let v = f64::from_bits((high as u64) << 32 | low as u64);
+                    let v: Option<<P as ArrowPrimitiveType>::Native> = NumCast::from(v);
+                    v.is_some()
+                }
+                _ => unreachable!(),
+            },
+            TapeElement::I64(high) => match tape.get(pos + 1) {
+                TapeElement::I32(low) => {
+                    let v = (high as i64) << 32 | (low as u32) as i64;
+                    let v: Option<<P as ArrowPrimitiveType>::Native> = NumCast::from(v);
+                    v.is_some()
+                }
+                _ => unreachable!(),
+            },
+            _ => false,
+        }
     }
 }

--- a/arrow-json/src/reader/string_array.rs
+++ b/arrow-json/src/reader/string_array.rs
@@ -133,15 +133,14 @@ impl<O: OffsetSizeTrait> ArrayDecoder for StringArrayDecoder<O> {
         match tape.get(pos) {
             TapeElement::String(_) => true,
             TapeElement::Null => self.is_nullable,
-            TapeElement::True | TapeElement::False | 
-            TapeElement::Number(_) |
-            TapeElement::I64(_) | TapeElement::I32(_) | 
-            TapeElement::F32(_) | TapeElement::F64(_) => {
-                self.coerce_primitive
-            }
-            _ => {
-                false
-            }
+            TapeElement::True
+            | TapeElement::False
+            | TapeElement::Number(_)
+            | TapeElement::I64(_)
+            | TapeElement::I32(_)
+            | TapeElement::F32(_)
+            | TapeElement::F64(_) => self.coerce_primitive,
+            _ => false,
         }
     }
 }

--- a/arrow-json/src/reader/timestamp_array.rs
+++ b/arrow-json/src/reader/timestamp_array.rs
@@ -118,7 +118,7 @@ where
                 if let Ok(d) = string_to_datetime(&self.timezone, s) {
                     match P::UNIT {
                         TimeUnit::Nanosecond => d.timestamp_nanos_opt().is_some(),
-                        _ => true
+                        _ => true,
                     }
                 } else {
                     false
@@ -132,7 +132,7 @@ where
                     .is_ok()
             }
             TapeElement::I32(_) | TapeElement::I64(_) => true,
-            _ => false
+            _ => false,
         }
     }
 }

--- a/arrow-json/src/reader/timestamp_array.rs
+++ b/arrow-json/src/reader/timestamp_array.rs
@@ -32,15 +32,17 @@ use crate::reader::ArrayDecoder;
 pub struct TimestampArrayDecoder<P: ArrowTimestampType, Tz: TimeZone> {
     data_type: DataType,
     timezone: Tz,
+    is_nullable: bool,
     // Invariant and Send
     phantom: PhantomData<fn(P) -> P>,
 }
 
 impl<P: ArrowTimestampType, Tz: TimeZone> TimestampArrayDecoder<P, Tz> {
-    pub fn new(data_type: DataType, timezone: Tz) -> Self {
+    pub fn new(data_type: DataType, timezone: Tz, is_nullable: bool) -> Self {
         Self {
             data_type,
             timezone,
+            is_nullable,
             phantom: Default::default(),
         }
     }
@@ -106,5 +108,31 @@ where
         }
 
         Ok(builder.finish().into_data())
+    }
+
+    fn validate_row(&self, tape: &Tape<'_>, pos: u32) -> bool {
+        match tape.get(pos) {
+            TapeElement::Null => self.is_nullable,
+            TapeElement::String(idx) => {
+                let s = tape.get_string(idx);
+                if let Ok(d) = string_to_datetime(&self.timezone, s) {
+                    match P::UNIT {
+                        TimeUnit::Nanosecond => d.timestamp_nanos_opt().is_some(),
+                        _ => true
+                    }
+                } else {
+                    false
+                }
+            }
+            TapeElement::Number(idx) => {
+                let s = tape.get_string(idx);
+                let b = s.as_bytes();
+                lexical_core::parse::<i64>(b)
+                    .or_else(|_| lexical_core::parse::<f64>(b).map(|x| x as i64))
+                    .is_ok()
+            }
+            TapeElement::I32(_) | TapeElement::I64(_) => true,
+            _ => false
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for ignoring (or optionally returning, as strings) JSON records that do not conform to the arrow schema.

The most obvious approach would be to do in a single pass: as we encounter a field that doesn't conform to the schema, we would then skip deserializing and move to the next row. However, this does not appear to be possible. Arrow-json decodes json in Arrays by column instead of row. That means that if we detect a problem in the second field, we have already built up the entire array for the first field.

Instead, we take a two-pass approach. First, we validate each row (via a new validate_row method on each array decoder) and determine which ones will be deserializable. Then, we deserialize only those rows (if the `allow_bad_data` option is set to true on the Decoder).

There is also a new `flush_with_bad_data` method on the Decoder which will partition the good and bad rows, deserialize the good rows into the RecordBatch, and return the bad rows as strings so that they can be handled alternately. It also returns a mask that tells us which of the original rowset was valid, which is helpful for excluding rows in companion arrays (like our timestamp array).